### PR TITLE
Add initial Docker logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+##
+# NOTICE
+#
+# Copyright (c) 2016 David C Vernet and Matthew J Perron. All rights reserved.
+#
+# Unless otherwise noted, all of the material in this file is Copyright (c) 2016
+# by David C Vernet and Matthew J Perron. All rights reserved. No part of this file
+# may be reproduced, published, distributed, displayed, performed, copied,
+# stored, modified, transmitted or otherwise used or viewed by anyone other
+# than the authors (David C Vernet and Matthew J Perron),
+# for either public or private use.
+#
+# No part of this file may be modified, changed, exploited, or in any way
+# used for derivative works or offered for sale without the express
+# written permission of the authors.
+#
+
+###############################################################################
+# Dockerfile for creating a docker image and testing that the compiled
+# JCoz shared library works on different platforms. To test on a specific
+# platform, change the FROM instruction argument to whatever base image
+# you'd like, and update the argument passed to entry.sh.
+# 
+# To build a docker image, perform the following steps:
+# 1. Run `docker build .` from the root directory of the project containing
+#		the dockerfile.
+# 2. Run `docker run <sha_ID_of_new_image>` to run the tests.
+#
+# TODO(david): Figure out how to get profile out of running container.
+#			   Need to figure out how to mount a volume on the container.
+# TODO(david): Have a more abstracted, well designed system for this
+#
+
+
+FROM centos
+MAINTAINER David Vernet <dcvernet@gmail.com>
+
+WORKDIR /jcoz/test
+
+
+# Add compiled shared library, test files, and dependencies
+ENV agentPath="liblagent.so"
+ENV testPath="test/Test.java"
+ENV testExec="file.sh"
+ADD lib/liblagent.so ${agentPath}
+ADD test/Test.java ${testPath}
+ADD file.sh file.sh
+ADD docker/debian_bootstrap.sh debian_bootstrap.sh
+ADD docker/redhat_bootstrap.sh redhat_bootstrap.sh
+ADD docker/entry.sh entry.sh
+
+# Run test
+ENTRYPOINT ["/bin/bash", "entry.sh", "redhat_bootstrap.sh"]

--- a/docker/debian_bootstrap.sh
+++ b/docker/debian_bootstrap.sh
@@ -1,0 +1,7 @@
+install_deps()
+{
+	apt-get -qq -y update
+	apt-get -qq -y install curl
+
+	apt-get -y install openjdk-7-jdk
+}

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,0 +1,10 @@
+# Get the dependencies from the given shell file
+source "$1"
+
+install_deps
+
+# Compile test
+javac test/*.java
+
+# Run profiler
+java -agentpath:./liblagent.so=pkg=test_progress-point=test/Test:38_warmup=1000_slow-exp test.Test

--- a/docker/redhat_bootstrap.sh
+++ b/docker/redhat_bootstrap.sh
@@ -1,0 +1,8 @@
+install_deps()
+{
+	yum -y update 
+	yum -y install curl
+	yum -y install java
+	yum install -y java-1.8.0-openjdk-devel
+}
+


### PR DESCRIPTION
- Add build files for installing RHEL and Debian dependencies.
- Add build file for installing platform dependencies and running
  JCoz tests.
- Pre-compiled binary runs fine on Centos >= 6 platforms. Does
  not run on Ubuntu <= 12.04.
- Need to figure out how to get profiles out of containers.
