### PR TITLE
Fix Makefile INCLUDEs and JavaFX maven dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ PLATFORM_WARNINGS:=-Wframe-larger-than=16384 \
 
 LIBS=-ldl -lpthread
 
-SRC_DIR:=$(PWD)/src/native
+SRC_ROOT:=$(PWD)/src
+SRC_DIR:=$(SRC_ROOT)/native
 BUILD_DIR?=$(shell mkdir build-$(BITS) 2> /dev/null; echo $(PWD)/build-$(BITS))
 
 OPT?=-O3
@@ -74,6 +75,7 @@ JAVA_HOME:=$(shell \
 
 INCLUDES=-I$(JAVA_HOME)/include \
 	-I$(JAVA_HOME)/include/$(UNAME) \
+	-I$(SRC_ROOT) \
 	-I/usr/include
 
 SOURCES=$(wildcard $(SRC_DIR)/*.cc)
@@ -86,7 +88,7 @@ $(BUILD_DIR)/%.pic.o: $(SRC_DIR)/%.cc
 all: native java tests
 
 native: $(OBJECTS)
-	$(CC) $(COPTS) -shared \
+	$(CC) $(COPTS) -shared $(INCLUDES) \
 	  -o $(BUILD_DIR)/$(TARGET) \
 	  -Bsymbolic $(OBJECTS) $(LIBS)
 

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -25,13 +25,6 @@
       <scope>system</scope>
       <systemPath>${java.home}/../lib/tools.jar</systemPath>
     </dependency>
-     <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>jfxrt</artifactId>
-      <version>1.0</version>
-      <scope>system</scope>
-      <systemPath>/usr/java/latest/jre/lib/ext/jfxrt.jar</systemPath>
-    </dependency>
     <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
     <dependency>
         <groupId>commons-cli</groupId>
@@ -45,6 +38,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.openjfx</groupId>
+        <artifactId>javafx-maven-plugin</artifactId>
+        <version>0.0.3</version>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
The Makefile was not passing the INCLUDE
to the recipe for compiling the native
agent, and the compilation was therefore
failing to find the requisite spdlog
headers.

Furthermore, JavaFX is required to build
the Java portion of JCoz. When the tool
was first built, there was no maven plugin
for JavaFX, and it was a nightmare to get
maven to point to the right jar file for
use when building the JCoz jar output.
This change updates pom to use the
now-available JavaFX plugin.