### PR TITLE
Revert "Fix Makefile INCLUDEs and JavaFX maven dependency"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ PLATFORM_WARNINGS:=-Wframe-larger-than=16384 \
 
 LIBS=-ldl -lpthread
 
-SRC_ROOT:=$(PWD)/src
-SRC_DIR:=$(SRC_ROOT)/native
+SRC_DIR:=$(PWD)/src/native
 BUILD_DIR?=$(shell mkdir build-$(BITS) 2> /dev/null; echo $(PWD)/build-$(BITS))
 
 OPT?=-O3
@@ -75,7 +74,6 @@ JAVA_HOME:=$(shell \
 
 INCLUDES=-I$(JAVA_HOME)/include \
 	-I$(JAVA_HOME)/include/$(UNAME) \
-	-I$(SRC_ROOT) \
 	-I/usr/include
 
 SOURCES=$(wildcard $(SRC_DIR)/*.cc)
@@ -88,7 +86,7 @@ $(BUILD_DIR)/%.pic.o: $(SRC_DIR)/%.cc
 all: native java tests
 
 native: $(OBJECTS)
-	$(CC) $(COPTS) -shared $(INCLUDES) \
+	$(CC) $(COPTS) -shared \
 	  -o $(BUILD_DIR)/$(TARGET) \
 	  -Bsymbolic $(OBJECTS) $(LIBS)
 

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -25,6 +25,13 @@
       <scope>system</scope>
       <systemPath>${java.home}/../lib/tools.jar</systemPath>
     </dependency>
+     <dependency>
+      <groupId>com.sun</groupId>
+      <artifactId>jfxrt</artifactId>
+      <version>1.0</version>
+      <scope>system</scope>
+      <systemPath>/usr/java/latest/jre/lib/ext/jfxrt.jar</systemPath>
+    </dependency>
     <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
     <dependency>
         <groupId>commons-cli</groupId>
@@ -38,12 +45,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-      </plugin>
-      <plugin>
-        <groupId>org.openjfx</groupId>
-        <artifactId>javafx-maven-plugin</artifactId>
-        <version>0.0.3</version>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
#39 Commit 01900a broke the docker build
because it moved the JavaFX jar around. Let's
revert my change for now and instead just remove
JavaFX from JCoz.

This reverts commit 01900a9cd9b9ec1648253b9cb0f9a5cd0de7b340.