### PR TITLE
Adding Dockerfile for Fedora

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,0 +1,18 @@
+FROM fedora:30
+
+RUN yum install -y \
+    gcc-c++ \
+    java-1.8.0-openjdk-devel \
+    java-1.8.0-openjdk-openjfx-devel \
+    make \
+    maven \
+    spdlog-devel \
+    which && \
+  mkdir -p /usr/java/latest/jre && \
+  ln -s /usr/lib/jvm/openjfx/rt/lib /usr/java/latest/jre/lib
+
+COPY . /jcoz
+
+WORKDIR /jcoz
+
+RUN make all


### PR DESCRIPTION
First step towards #42 - tested against `fedora:25` thru `fedora:31`. 

Did not work on `fedora:24` due to an error about them deprecating `yum`, did not spend any time investigating a possible solution.

Run with:
```
docker build . -f Dockerfile.fedora -t jcoz:fedora-30
```