### PR TITLE
Fix Makefile dependency and speed up Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY . /jcoz
 
 WORKDIR /jcoz
 
-RUN make all
+RUN make -j`nproc` all
 
 FROM openjdk:8-slim
 

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -15,4 +15,4 @@ COPY . /jcoz
 
 WORKDIR /jcoz
 
-RUN make all
+RUN make -j`nproc` all

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ native: $(OBJECTS)
 java:
 	mvn -f src/java/pom.xml install
 
-tests:
+tests: java
 	javac src/java/src/test/java/test/*.java -cp src/java/target/client*dependencies.jar
 
 clean:


### PR DESCRIPTION
The "tests" make target requires the jar to have
been built by maven before compiling the tests.
This change corrects that by specifying the java
target as a dependency of tests.

Additionally, when building the JCoz Docker image,
make is invoked without any parallelism. This
commit optimizes the build by invoking make with
the # of cores present on the system. Doing so
results in the following speedups:

Dockerfile:
no -j\`nproc\` | with -j\`nproc\`
\------------------------------
0m34.704s    | 0m26.798s

Dockerfile.fedora:
no -j\`nproc\` | with -j\`nproc\`
\------------------------------
0m41.974s    | 0m25.191s

This is to be expected, as we're now compiling the
native agent in parallel with building the maven
jar and compiling the tests.