### PR TITLE
Remove JavaFX dependencies from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,7 @@ RUN apt-get update && \
   apt-get install -y \
     g++ \
     libspdlog-dev \
-    make \
-    openjfx && \
-  mkdir -p /usr/java/ && \
-  ln -nfs /usr/share/java/openjfx /usr/java/latest
+    make
 
 COPY . /jcoz
 

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -3,13 +3,10 @@ FROM fedora:30
 RUN yum install -y \
     gcc-c++ \
     java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk-openjfx-devel \
     make \
     maven \
     spdlog-devel \
-    which && \
-  mkdir -p /usr/java/latest/jre && \
-  ln -s /usr/lib/jvm/openjfx/rt/lib /usr/java/latest/jre/lib
+    which
 
 COPY . /jcoz
 


### PR DESCRIPTION
Now that commit bd444c5 has been merged,
and JavaFX has been removed from the
codebase, it is no longer required to
include it as a dependency in our
Dockerfile scripts. This change therefore
removes all logic to download or install
JavaFX from the Dockerfiles.

Testing Done: Built both docker images.