### PR TITLE
Support spdlog version before v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ GLOBAL_COPTS=-fdiagnostics-show-option \
 	-g \
 	-D__STDC_FORMAT_MACROS
 
+ifeq ($(shell test -f "/usr/include/spdlog/sinks/file_sinks.h" && echo -n yes), yes)
+	PLATFORM_COPTS := $(PLATFORM_COPTS) -DSPDLOG_OLD
+endif
+
 COPTS:=$(PLATFORM_COPTS) \
 	$(GLOBAL_COPTS) \
 	$(PLATFORM_WARNINGS) \

--- a/src/native/profiler.h
+++ b/src/native/profiler.h
@@ -33,7 +33,11 @@
 #include "stacktraces.h"
 #include "spdlog/spdlog.h"
 #ifdef SPDLOG_VERSION
+#ifdef SPDLOG_OLD
+#include "spdlog/sinks/file_sinks.h"
+#else
 #include "spdlog/sinks/basic_file_sink.h"
+#endif
 #endif
 
 #ifndef PROFILER_H


### PR DESCRIPTION
Before v1 include name for file spdlog's sink was file_sinks.h and in v1 it has been changed to basic_file_sink.h.

This patch allows successful compilation on Linux Mint 19.2 and probably fix Ubuntu too.