### PR TITLE
Remove unused ParseOptions logic from native agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 bin/
 build-64/
 build/
+jcoz/
 out
 questions
 src/java/target

--- a/src/native/entry.cc
+++ b/src/native/entry.cc
@@ -412,11 +412,6 @@ AGENTEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options,
     return 1;
   }
 
-
-
-//  // Read the command line options and set progress points and package
-//  prof->ParseOptions(options);
-
   if (!PrepareJvmti(jvmti)) {
     fprintf(stderr, "Failed to initialize JVMTI.  Continuing...\n");
     return 0;

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -132,73 +132,11 @@ inline long jcoz_sleep(long nanoseconds) {
 	return total_sleep.count();
 }
 
-void Profiler::ParseOptions(const char *options) {
-
-    if( options == NULL ) {
-    	fprintf(stderr, "Missing options\n");
-        print_usage();
-        exit(1);
-    }else{
-    	logger->info("Received options: {}", options);
-    }
-    std::string options_str(options);
-    std::stringstream ss(options_str);
-    std::string item;
-    std::vector<std::string> cmd_line_options;
-    progress_point = new ProgressPoint();
-    progress_point->lineno = -1;
-    progress_point->method_id = nullptr;
-
-    // split underscore delimited line into options
-    // (we can't use semicolon because bash is dumb)
-    while( std::getline(ss, item, '_') ) {
-        cmd_line_options.push_back(item);
-    }
-
-    for( auto i = cmd_line_options.begin(); i != cmd_line_options.end(); i++ ) {
-        size_t equal_index = i->find('=');
-        std::string option = i->substr(0, equal_index);
-        std::string value = i->substr(equal_index + 1);
-
-        // extract package
-        if( option == "pkg" || option == "package" ) {
-            this->package = value;
-        } else if (option == "progress-point") {
-
-        // else extract progress point
-            size_t colon_index = value.find(':');
-            if( colon_index == std::string::npos ) {
-            	fprintf(stderr, "Missing progress point\n");
-                print_usage();
-                exit(1);
-            }
-
-            this->progress_class = value.substr(0, colon_index);
-            progress_point->lineno = std::stoi(value.substr(colon_index + 1));
-
-        } else if (option == "end-to-end") {
-            end_to_end = true;
-        } else if (option == "warmup") {
-            // We expect # of milliseconds so multiply by 1000 for usleep (takes microseconds)
-            warmup_time = std::stol(value) * 1000;
-        } else if (option == "fix-exp" ) {
-            fix_exp = true;
-        }
-    }
-
-    if( this->package.empty() || (!end_to_end && (progress_class.empty() || progress_point->lineno == -1)) ) {
-    	fprintf(stderr, "Missing package, progress class, or progress point\n");
-        print_usage();
-        exit(1);
-    }
-}
-
 void Profiler::init(){
 	progress_point = new ProgressPoint();
 	progress_point->lineno = -1;
 	progress_point->method_id = nullptr;
 }
-
 
 jvmtiEnv * Profiler::getJVMTI(){
 	return jvmti_;

--- a/src/native/profiler.h
+++ b/src/native/profiler.h
@@ -87,8 +87,6 @@ class Profiler {
 
   void Stop();
 
-  void ParseOptions(const char *options);
-
   static std::string &getPackage() { return package; }
 
   static std::string &getProgressClass() { return progress_class; }


### PR DESCRIPTION
In JCoz' early days, there was no Java
component, and profiling a JVM process
simply involved invoking java on the
process with the native agent, and a
set of passed parameters. Now that
profiling parameters such as progress
point class/line number are passed down
to the native agent through JNI calls
from the JCoz Java service, the user
need no longer configure where the
progress point is set via passing a
long continuous argument string as
part of the java nativeagent parameter.

As a first step in the direction towards
documenting and refactoring the native
Profiler class (#56), this commit
removes the logic from the nativeagent
to parse and configure nativeagent
parameters from the user.