### PR TITLE
Log what bytecode indexes/lines/methods and how often were selected for experiments

### DIFF
--- a/src/native/bci_hits.cc
+++ b/src/native/bci_hits.cc
@@ -1,0 +1,34 @@
+#include "bci_hits.h"
+
+#include <sstream>
+#include "spdlog/spdlog.h"
+
+void bci_hits::add_hit(char* class_fqn, jmethodID method_id, jint line_number, jint bci)
+{
+  _freqs[method_id][line_number][bci]++;
+  _declaring_classes[method_id] = class_fqn;
+}
+
+std::vector<std::string> bci_hits::create_dump(jvmtiEnv* dealloc_jvmti)
+{
+  std::vector<std::string> result;
+  result.emplace_back("Bytecode index hits:");
+  for (auto method_it = _freqs.begin(); method_it != _freqs.end(); ++method_it)
+  {
+    char* class_fqn = _declaring_classes[method_it->first];
+    result.push_back(fmt::format("\tFor class {}:", class_fqn));
+    for (auto line_it = method_it->second.begin(); line_it != method_it->second.end(); ++line_it)
+    {
+      jint line_number = line_it->first;
+      std::stringstream ss;
+      ss << "\t\t" << line_number << ": ";
+      for (auto bci_it = line_it->second.begin(); bci_it != line_it->second.end(); ++bci_it)
+      {
+        ss << fmt::format("({}, {}); ", bci_it->first, bci_it->second);
+      }
+      result.emplace_back(ss.str());
+    }
+    dealloc_jvmti->Deallocate(reinterpret_cast<unsigned char*>(class_fqn));
+  }
+  return result;
+}

--- a/src/native/bci_hits.h
+++ b/src/native/bci_hits.h
@@ -1,0 +1,23 @@
+#ifndef JCOZ_BCI_HITS_H
+#define JCOZ_BCI_HITS_H
+
+#include "globals.h"
+#include <vector>
+#include <map>
+
+namespace bci_hits
+{
+    using hit_freq_t = std::map<jint, unsigned int>;
+
+    void add_hit(char* class_fqn, jmethodID method_id, jint line_number, jint bci);
+
+    std::vector<std::string> create_dump(jvmtiEnv* dealloc_jvmti);
+
+    namespace
+    {
+      std::map<jmethodID, std::map<jint, hit_freq_t>> _freqs;
+      std::map<jmethodID, char*> _declaring_classes;
+    }
+} // namespace bci_hits
+
+#endif //JCOZ_BCI_HITS_H

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -42,6 +42,7 @@
 
 #include "display.h"
 #include "globals.h"
+#include "bci_hits.h"
 
 #ifdef __APPLE__
 // See comment in Accessors class
@@ -91,8 +92,6 @@ bool Profiler::prof_ready = false;
 std::string Profiler::package;
 struct ProgressPoint* Profiler::progress_point = nullptr;
 std::string Profiler::progress_class;
-std::map<jmethodID, std::map<jint, bci_hits::hit_freq_t>> bci_hits::_freqs;
-std::map<jmethodID, char*> bci_hits::_declaring_classes;
 
 static std::atomic<int> call_index(0);
 static JVMPI_CallFrame static_call_frames[NUM_CALL_FRAMES];
@@ -787,7 +786,7 @@ void Profiler::Stop() {
     logger->info("Profiler finished current cycle...");
   }
 
-  std::vector<std::string> hits = bci_hits::create_dump();
+  std::vector<std::string> hits = bci_hits::create_dump(jvmti);
   for (std::string& hit : hits) {
       logger->info("{}", hit);
   }
@@ -810,35 +809,3 @@ Profiler::HandleBreakpoint(
     ) {
   curr_ut->points_hit += in_experiment;
 }
-
-void bci_hits::add_hit(char* class_fqn, jmethodID method_id, jint line_number, jint bci)
-{
-    _freqs[method_id][line_number][bci]++;
-    _declaring_classes[method_id] = class_fqn;
-}
-
-std::vector<std::string> bci_hits::create_dump()
-{
-    std::vector<std::string> result;
-    result.emplace_back("Bytecode index hits:");
-    for (auto method_it = _freqs.begin(); method_it != _freqs.end(); ++method_it)
-    {
-        char* class_fqn = _declaring_classes[method_it->first];
-        result.emplace_back(fmt::format("\tFor class {}:", class_fqn));
-        for (auto line_it = method_it->second.begin(); line_it != method_it->second.end(); ++line_it)
-        {
-            jint line_number = line_it->first;
-            std::stringstream ss;
-            ss << "\t\t" << line_number << ": ";
-            for (auto bci_it = line_it->second.begin(); bci_it != line_it->second.end(); ++bci_it)
-            {
-                ss << fmt::format("({}, {}); ", bci_it->first, bci_it->second);
-            }
-            result.emplace_back(ss.str());
-        }
-        free(class_fqn);
-    }
-    return result;
-}
-
-

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -91,7 +91,8 @@ bool Profiler::prof_ready = false;
 std::string Profiler::package;
 struct ProgressPoint* Profiler::progress_point = nullptr;
 std::string Profiler::progress_class;
-
+std::map<jmethodID, std::map<jint, bci_hits::hit_freq_t>> bci_hits::_freqs;
+std::map<jmethodID, char*> bci_hits::_declaring_classes;
 
 static std::atomic<int> call_index(0);
 static JVMPI_CallFrame static_call_frames[NUM_CALL_FRAMES];
@@ -258,6 +259,8 @@ void Profiler::runExperiment(JNIEnv * jni_env) {
     }
   }
 
+  bci_hits::add_hit(sig, current_experiment.method_id, current_experiment.lineno, current_experiment.bci);
+
   // Log the run experiment results
   logger->info(
       "Ran experiment: [class: {class}:{line_no}] [speedup: {speedup}] [points hit: {points_hit}] [delay: {delay}] [duration: {duration}] [new exp time: {exp_time}]",
@@ -267,7 +270,6 @@ void Profiler::runExperiment(JNIEnv * jni_env) {
   logger->flush();
 
   delete[] current_experiment.location_ranges;
-  free(sig);
 
   logger->info("Finished experiment, flushed logs, and delete current location ranges.");
 }
@@ -340,6 +342,7 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args) {
 
       logger->debug("Found in scope frames. Choosing a frame and running experiment...");
       current_experiment.method_id = exp_frame.method_id;
+      current_experiment.bci = exp_frame.lineno;
       jint start_line;
       jint end_line; //exclusive
       jint line = -1;
@@ -784,6 +787,10 @@ void Profiler::Stop() {
     logger->info("Profiler finished current cycle...");
   }
 
+  std::vector<std::string> hits = bci_hits::create_dump();
+  for (std::string& hit : hits) {
+      logger->info("{}", hit);
+  }
   clearInScopeMethods();
   signal(SIGPROF, SIG_IGN);
   logger->flush();
@@ -803,4 +810,35 @@ Profiler::HandleBreakpoint(
     ) {
   curr_ut->points_hit += in_experiment;
 }
+
+void bci_hits::add_hit(char* class_fqn, jmethodID method_id, jint line_number, jint bci)
+{
+    _freqs[method_id][line_number][bci]++;
+    _declaring_classes[method_id] = class_fqn;
+}
+
+std::vector<std::string> bci_hits::create_dump()
+{
+    std::vector<std::string> result;
+    result.emplace_back("Bytecode index hits:");
+    for (auto method_it = _freqs.begin(); method_it != _freqs.end(); ++method_it)
+    {
+        char* class_fqn = _declaring_classes[method_it->first];
+        result.emplace_back(fmt::format("\tFor class {}:", class_fqn));
+        for (auto line_it = method_it->second.begin(); line_it != method_it->second.end(); ++line_it)
+        {
+            jint line_number = line_it->first;
+            std::stringstream ss;
+            ss << "\t\t" << line_number << ": ";
+            for (auto bci_it = line_it->second.begin(); bci_it != line_it->second.end(); ++bci_it)
+            {
+                ss << fmt::format("({}, {}); ", bci_it->first, bci_it->second);
+            }
+            result.emplace_back(ss.str());
+        }
+        free(class_fqn);
+    }
+    return result;
+}
+
 

--- a/src/native/profiler.h
+++ b/src/native/profiler.h
@@ -52,19 +52,6 @@ struct Experiment {
   int num_ranges;
 };
 
-class bci_hits
-{
-public:
-    using hit_freq_t = std::map<jint, unsigned int>;
-
-    static void add_hit(char* class_fqn, jmethodID method_id, jint line_number, jint bci);
-    static std::vector<std::string> create_dump();
-
-private:
-    static std::map<jmethodID, std::map<jint, hit_freq_t>> _freqs;
-    static std::map<jmethodID, char*> _declaring_classes;
-};
-
 struct UserThread {
   pthread_t thread;
   long local_delay = 0;

--- a/src/native/profiler.h
+++ b/src/native/profiler.h
@@ -28,6 +28,7 @@
 #include <pthread.h>
 #include <fstream>
 #include <iostream>
+#include <map>
 
 #include "globals.h"
 #include "stacktraces.h"
@@ -46,8 +47,22 @@ struct Experiment {
   long duration = 0;
   jmethodID method_id;
   jint lineno;
+  jint bci;
   std::pair<jint,jint> *location_ranges;
   int num_ranges;
+};
+
+class bci_hits
+{
+public:
+    using hit_freq_t = std::map<jint, unsigned int>;
+
+    static void add_hit(char* class_fqn, jmethodID method_id, jint line_number, jint bci);
+    static std::vector<std::string> create_dump();
+
+private:
+    static std::map<jmethodID, std::map<jint, hit_freq_t>> _freqs;
+    static std::map<jmethodID, char*> _declaring_classes;
 };
 
 struct UserThread {


### PR DESCRIPTION
This can give useful information about where are hot spots exactly. Indeed, profiler will still speedup virtually the whole line and not particular bytecode instruction, but knowing such hot instructions might guide where the opportunity of optimization is.